### PR TITLE
Remove all hardcoded (serial) console service files

### DIFF
--- a/board/monome/common/post-build.sh
+++ b/board/monome/common/post-build.sh
@@ -3,6 +3,13 @@ set -e
 
 BOARD_DIR="$(dirname $0)"
 
+# Fix for buildroot adding an unnecessary default (console-|serial-)getty@.service
+# Systemd will automatically pick up the kernel's console=<console> parameter and create
+# serial-console@<console>.service
+# Having an additional one makes no sense and depending on the value of
+# BR2_TARGET_GENERIC_GETTY_PORT breaks things
+rm -rf ${TARGET_DIR}/etc/systemd/system/getty.target.wants/
+
 # Rename dt-blob.dtb to dt-blob.bin
 if [ -f ${BINARIES_DIR}/dt-blob.dtb ]; then
   mv "${BINARIES_DIR}/dt-blob.dtb" "${BINARIES_DIR}/dt-blob.bin"


### PR DESCRIPTION
These are incorrectly created by buildroot and cause either a warning or real issues where the serial console won't work
depending on what BR2_TARGET_GENERIC_GETTY_PORT is set to.
To ensure this doesn't happen we simply delete all the files (which buildroot has created) in /etc/systemd/system/getty.target.wants

This behavior has been incorrect in buildroot for a while but with the introduction of https://github.com/buildroot/buildroot/commit/940e7deab09e34585a5b70dd6ce1c9afd22fd8f3 it broke our serial console.

The default should be to not create any of these when systemd is used and let the user add additional ones if he/she wants to.